### PR TITLE
WEB: Removing links to scalers

### DIFF
--- a/data/en/links.yaml
+++ b/data/en/links.yaml
@@ -26,20 +26,6 @@
         FLAC without any loss in quality. ScummVM optionally supports playback
         of CD tracks and other audio data encoded using FLAC.
       url: 'https://xiph.org/flac/'
-    - name: Scale2x/3x/4x
-      notes: >-
-        Scale2x is a real-time graphics effect able to increase the size of
-        small bitmaps guessing the missing pixels without blurring the images.
-        ScummVM optionally supports enlarging the game graphics using this
-        scaler.
-      url: 'http://www.scale2x.it/'
-    - name: hq2x/3x/4x
-      notes: >-
-        The hq2x/3x/4x filters form a family of fast, high-quality magnification
-        filters. ScummVM optionally supports enlarging the game graphics using
-        these scaler.
-      url: >-
-        https://web.archive.org/web/20131114143602/http://www.hiend3d.com/hq3x.html
 - name: Game mods made possible by ScummVM
   notes: >-
     The following are links to projects that modify games in ways that were not possible in the original game engines,


### PR DESCRIPTION
These scalers, and many more, are already [documented in the ScummVM docs](https://docs.scummvm.org/en/latest/advanced_topics/understand_graphics.html?highlight=sdl#a-comparison-of-sdl-surface-software-scalers), so it's redundant to have them here (and without the other scalers). Plus one of the websites isn't live any more and only linked via Wayback Machine.